### PR TITLE
feat: Add snapshot debugging analysis to Dean Debug

### DIFF
--- a/domains/dean-debug/mdc-file-format.md
+++ b/domains/dean-debug/mdc-file-format.md
@@ -1,0 +1,115 @@
+---
+title: "MDC Debug Trace File Format"
+domain: "dean-debug"
+difficulty: "advanced"
+bc_versions: "14+"
+tags: ["debugging", "snapshot", "mdc", "call-stack", "variables", "binary-format"]
+samples: "samples/mdc-file-format.md"
+type: "architecture-pattern"
+category: "debugging"
+pattern_type: "good"
+severity: "medium"
+impact_level: "high"
+
+relevance_signals:
+  constructs: []
+  keywords: ["mdc", "debug trace", "call stack", "variable values", "record data", "snapshot"]
+  anti_pattern_indicators: []
+  positive_pattern_indicators: ["mdc analysis", "trace interpretation", "debug data"]
+
+applicable_object_types: ["codeunit", "page", "table", "report", "query"]
+
+relevance_threshold: 0.6
+---
+
+# MDC Debug Trace File Format
+
+## Overview
+
+MDC files (.mdc) are binary debug trace files within BC snapshots that contain execution step data including call stacks, variable values, and record field contents. While binary, they contain readable text segments that can be extracted and interpreted.
+
+**Core Principle**: Each .mdc file represents one execution step, containing the complete call stack and all variable/record values at that moment in time.
+
+## How It Works
+
+MDC files use a binary format with embedded text strings. Key data sections include:
+
+### Header Section (First ~200 bytes)
+- File structure metadata
+- Timestamps (8-byte values)
+- Offset pointers to data sections
+
+### App Metadata Section
+- **App ID**: 32-character hex GUID (no dashes)
+- **Version**: Full version string
+- **Publisher**: Publisher name
+- **App Name**: Application name
+
+### Call Stack Section
+Each stack frame contains:
+- **Object Name**: e.g., "Whse. Item Journal", "Whse. Jnl.-Register Batch"
+- **Procedure Name**: e.g., "OnAfterGetRecord", "Code", "CheckItemAvailability"
+- **Line Position**: Two 16-bit little-endian values (line, column)
+
+### Variable Data Section (larger .mdc files)
+Contains field-by-field record data:
+- **Data Type**: Boolean, Integer, Decimal, Text[N], Code[N], GUID, DateTime, Option
+- **Field Name**: Human-readable field name
+- **Value**: Current value as text
+
+## Reading Line Numbers
+
+Line numbers are stored as 16-bit little-endian integers. For example:
+- `78 01` in hex = 0x0178 = 376 decimal
+- `aa 01` in hex = 0x01aa = 426 decimal
+
+These correspond directly to line numbers in the accompanying .al source files.
+
+## Identifying Call Stack Depth
+
+The call stack shows the execution path, read from bottom to top:
+1. Entry point (trigger or action)
+2. Called procedures
+3. Current executing procedure (top of stack)
+
+Stack entries appear in sequence in the .mdc file, each with:
+- Object type and name
+- Procedure/trigger name
+- Source position
+
+## Variable Value Patterns
+
+Variable data appears in larger .mdc files with this pattern:
+```
+[type info] [data type name] [value] [field name]
+```
+
+Common patterns:
+- `Boolean` followed by `True`/`False`/`Yes`/`No`
+- `Decimal` followed by numeric string like `0`
+- `Text[N]` or `Code[N]` followed by quoted value like `''`
+- `DateTime` followed by formatted date `08.04.25 17:15:36,543`
+- `GUID` followed by bracketed GUID `{02D08B59-DDB3-47B2-BD51-6A537EBC478C}`
+
+## Record Field Counts
+
+When viewing record variables, look for `Count = N` which indicates how many fields are present. For example, `Count = 62` means 62 fields follow in the data section.
+
+## File Size Correlation
+
+- **Small .mdc files** (~400-1200 bytes): Basic stack frame, few/no variables
+- **Medium .mdc files** (~1500-10000 bytes): Stack with some variable data
+- **Large .mdc files** (10KB+): Rich variable data, often at breakpoints or key execution points
+
+The largest .mdc file in a snapshot often contains the most interesting debugging data.
+
+## Summary
+
+- MDC files are binary but contain extractable text data
+- Call stacks show the full execution path with line numbers
+- Variable values include type, name, and current value
+- Line numbers map directly to .al source files in the snapshot
+- Larger files contain richer debugging data
+
+*Code examples: see samples/mdc-file-format.md*
+*Related patterns: snapshot-debugging-structure.md, snapshot-analysis-workflow.md*

--- a/domains/dean-debug/samples/mdc-file-format.md
+++ b/domains/dean-debug/samples/mdc-file-format.md
@@ -1,0 +1,140 @@
+# MDC Debug Trace File Format - Examples
+
+## Call Stack from .mdc File
+
+Raw text extracted from 50.mdc showing call stack:
+```
+Whse. Item Journal        &Register - OnAction
+Whse. Jnl.-Register       OnRun
+Whse. Jnl.-Register       Code
+Whse. Jnl.-Register Batch OnRun
+Whse. Jnl.-Register Batch Code
+Whse. Jnl.-Register Batch CheckItemAvailability
+Whse. Jnl.-Register Batch CalcReservedQtyOnInventory
+```
+
+Reading bottom-to-top, this means:
+1. User clicked Register action on Whse. Item Journal page
+2. Called Whse. Jnl.-Register.OnRun
+3. Which called Code procedure
+4. Which called Whse. Jnl.-Register Batch.OnRun
+5. Eventually reaching CalcReservedQtyOnInventory
+
+## Line Number Decoding
+
+Hex bytes `78 01 1d 00` decode as:
+- `78 01` = 0x0178 = **line 376**
+- `1d 00` = 0x001d = **column 29**
+
+Corresponding AL source (Page 7324):
+```al
+375→    trigger OnAfterGetRecord()
+376→    begin                          // ← Line 376
+377→        IsVariantMandatory();
+378→    end;
+```
+
+Another example - `aa 01 22 00`:
+- `aa 01` = 0x01aa = **line 426**
+- `22 00` = 0x0022 = **column 34**
+
+```al
+423→    local procedure IsVariantMandatory()
+424→    var
+425→        Item: Record Item;
+426→    begin                          // ← Line 426
+427→        if Rec."Variant Code" = '' then
+```
+
+## Variable Data Patterns
+
+### Boolean Variables
+```
+Boolean     False       IsHandled
+Boolean     No          Has Hard Commits
+```
+
+### Decimal Variables
+```
+Decimal     0           Bin Committed Quantity
+Decimal     0           Committed Quantity
+Decimal     0           Quantity (Base)
+Decimal     0           Pick Qty.
+```
+
+### Text/Code Variables
+```
+Text[100]   ''          Wine Description
+Code[100]   ''          Search Code
+Text[50]    ''          Wine Producer
+```
+
+### DateTime Variables
+```
+DateTime    08.04.25 17:15:36,543    SystemModifiedAt
+DateTime    08.04.25 17:15:36,543    SystemCreatedAt
+```
+
+### GUID Variables
+```
+GUID    {02D08B59-DDB3-47B2-BD51-6A537EBC478C}    SystemModifiedBy
+GUID    {589AE851-8C14-F011-9346-6045BD29AC14}    $systemId
+```
+
+### Option Variables
+```
+Option      (space)     Wine Color
+```
+
+### Table Location (Uninitialized Record)
+```
+Table Location (14)     <Uninitialized>     Location
+```
+
+## Record Field Count
+
+When a record variable is captured, you'll see:
+```
+Count = 62
+Fields
+```
+Followed by 62 field entries with type, value, and name.
+
+## File Size vs Content Correlation
+
+| Size | Content Type | Example |
+|------|--------------|---------|
+| ~400 bytes | Session start, minimal data | 0.mdc |
+| ~500-1000 bytes | Single stack frame, no vars | 1.mdc, 2.mdc |
+| ~1000-1500 bytes | Deeper stack, few vars | Most numbered files |
+| ~10KB | Rich variable data | 19.mdc |
+| ~70KB | Very rich data, likely breakpoint | 225.mdc |
+
+## Raw Hex Pattern Recognition
+
+App ID pattern (32 hex chars, no dashes):
+```
+3433 3764 6266 3065 3834 6666 3431 3761
+3936 3564 6564 3262 6239 3635 3039 3732
+```
+
+Procedure name patterns - look for readable ASCII:
+```
+4f6e 4166 7465 7247 6574 5265 636f 7264 = OnAfterGetRecord
+436f 6465                               = Code
+4f6e 5275 6e                            = OnRun
+```
+
+## Extracting Multiple Call Stacks
+
+From a session with 579 .mdc files, you can trace the full execution:
+
+```
+0.mdc:   Whse. Item Journal → OnAfterGetRecord
+1.mdc:   Whse. Item Journal → IsVariantMandatory
+2.mdc:   Item → IsVariantMandatory (calling into Item table)
+...
+225.mdc: Deep in CreateTrackingSpecification with full record data
+...
+578.mdc: Final step of execution
+```

--- a/domains/dean-debug/samples/snapshot-analysis-workflow.md
+++ b/domains/dean-debug/samples/snapshot-analysis-workflow.md
@@ -1,0 +1,182 @@
+# Snapshot Debugging Analysis Workflow - Examples
+
+## Phase 1: Initial Assessment Example
+
+### Step 1: Count Execution Steps
+```bash
+ls *.mdc | wc -l
+# Result: 579 steps captured
+```
+
+### Step 2: List Objects Involved
+```bash
+ls *.al
+# CodeUnit%6500.al  - Item Tracking Management
+# CodeUnit%6516.al  - Item Tracking Data Collection
+# CodeUnit%7302.al  - Whse. Jnl.-Register Batch
+# CodeUnit%7303.al  - Whse. Jnl.-Register
+# CodeUnit%7304.al  - Whse. Jnl.-Register Line
+# Page%7324.al      - Whse. Item Journal
+# Table%27.al       - Item
+# Table%6550.al     - Whse. Item Tracking Line
+# Table%6565.al     - Tracking Specification
+# Table%7302.al     - Warehouse Journal Line
+# Table%7311.al     - Warehouse Journal Batch
+```
+
+### Step 3: Check Version
+```bash
+cat version
+# (May be empty or contain version marker)
+# App metadata in .mdc shows: 26.5.38752.42305
+```
+
+## Phase 2: Find Key Points Example
+
+### Sort by Size
+```bash
+ls -laS *.mdc | head -5
+# 71800 bytes  225.mdc  ← Investigate this first
+#  9928 bytes  19.mdc   ← Also interesting
+#  1624 bytes  185.mdc
+#  1608 bytes  202.mdc
+#  1520 bytes  198.mdc
+```
+
+### Why 225.mdc is Key
+At 71KB, this file contains:
+- Full call stack (7+ frames deep)
+- Complete record data (62 fields)
+- Multiple variable values
+- Likely captured at a breakpoint or key execution point
+
+## Phase 3: Extract Call Stack Example
+
+From 225.mdc, extracted call stack (bottom to top):
+```
+1. Page "Whse. Item Journal" → &Register - OnAction
+   ↓
+2. Codeunit "Whse. Jnl.-Register" → OnRun
+   ↓
+3. Codeunit "Whse. Jnl.-Register" → Code
+   ↓
+4. Codeunit "Whse. Jnl.-Register Batch" → OnRun
+   ↓
+5. Codeunit "Whse. Jnl.-Register Batch" → Code
+   ↓
+6. Codeunit "Whse. Jnl.-Register Batch" → CheckLines
+   ↓
+7. Codeunit "Whse. Jnl.-Register Batch" → CreateTrackingSpecification
+```
+
+**Interpretation**: User clicked Register, system is validating and creating tracking specifications.
+
+## Phase 4: Examine Variables Example
+
+From 225.mdc variable section:
+
+### Boolean State
+```
+IsHandled = False        # Event not handled by subscriber
+Has Hard Commits = No    # No committed transactions yet
+```
+
+### Quantity Fields (All Zero)
+```
+Quantity = 0
+Quantity (Base) = 0
+Pick Qty. = 0
+Put-away Qty. = 0
+Committed Quantity = 0
+```
+
+### System Fields
+```
+$systemId = {589AE851-8C14-F011-9346-6045BD29AC14}
+SystemCreatedAt = 08.04.25 17:15:36,543
+SystemModifiedAt = 08.04.25 17:15:36,543
+SystemCreatedBy = {02D08B59-DDB3-47B2-BD51-6A537EBC478C}
+```
+
+### Custom Fields (Empty)
+```
+Wine Description = ''
+Wine Producer = ''
+Search Code = ''
+Wine Vintage = 0
+```
+
+## Phase 5: Correlate with Source Example
+
+### From .mdc: Line 376 in Page 7324
+Hex: `78 01` = 0x0178 = 376
+
+### Lookup in Page%7324.al:
+```al
+375→    trigger OnAfterGetRecord()
+376→    begin                          // ← Execution here
+377→        IsVariantMandatory();
+378→    end;
+```
+
+### From .mdc: Line 426 in Page 7324
+Hex: `aa 01` = 0x01aa = 426
+
+### Lookup in Page%7324.al:
+```al
+423→    local procedure IsVariantMandatory()
+424→    var
+425→        Item: Record Item;
+426→    begin                          // ← Execution here
+427→        if Rec."Variant Code" = '' then
+428→            VariantCodeMandatory := Item.IsVariantMandatory(true, Rec."Item No.");
+```
+
+## Phase 6: Build the Story Example
+
+### Investigation Summary
+
+**Scenario**: Warehouse Item Journal registration
+
+**Entry Point**: User clicked Register action on Page 7324 (Whse. Item Journal)
+
+**Execution Path**:
+1. OnAction triggered Whse. Jnl.-Register codeunit
+2. Register codeunit called batch processing
+3. Batch processing checked lines and created tracking specs
+4. 579 total execution steps captured
+
+**Key Observations**:
+- All quantity fields were zero at capture point
+- IsHandled was false (no subscriber intervention)
+- Custom wine-related fields were empty (possibly extension fields)
+- System timestamps show record was created/modified at 17:15:36
+
+**Potential Issues to Investigate**:
+- Why are quantities zero? Expected non-zero for journal registration
+- Wine fields suggest custom extension - check for conflicts
+- Look earlier in trace (lower .mdc numbers) to see when quantities were set
+
+## Common Analysis Patterns
+
+### Finding Where a Value Changed
+```bash
+# Search for field name across .mdc files
+grep -l "Quantity" *.mdc | head -10
+# Then examine those files for value changes
+```
+
+### Tracing Backward from Error
+```bash
+# Start from end of trace
+cat 578.mdc | strings | grep -A5 -B5 "Error"
+cat 577.mdc | strings | grep -A5 -B5 "Error"
+# Work backward until you find good state
+```
+
+### Finding Loop Iterations
+```bash
+# Count occurrences of a procedure
+grep -c "OnAfterGetRecord" *.mdc 2>/dev/null | grep -v ":0"
+# High counts indicate loop execution
+```

--- a/domains/dean-debug/samples/snapshot-debugging-structure.md
+++ b/domains/dean-debug/samples/snapshot-debugging-structure.md
@@ -1,0 +1,89 @@
+# Snapshot Debugging File Structure - Examples
+
+## Extracted Snapshot Contents
+
+A typical extracted snapshot contains:
+```
+d772d7c2-e832-4b80-b758-c59dca196321/
+├── 0.mdc           # First execution step
+├── 1.mdc           # Second execution step
+├── 2.mdc           # Third execution step
+├── ...
+├── 578.mdc         # Last execution step (579 total steps)
+├── CodeUnit%6500.al    # Item Tracking Management
+├── CodeUnit%6516.al    # Item Tracking Data Collection
+├── CodeUnit%7302.al    # Whse. Jnl.-Register Batch
+├── CodeUnit%7303.al    # Whse. Jnl.-Register
+├── CodeUnit%7304.al    # Whse. Jnl.-Register Line
+├── Page%7324.al        # Whse. Item Journal
+├── Table%27.al         # Item
+├── Table%6550.al       # Whse. Item Tracking Line
+├── Table%6565.al       # Tracking Specification
+├── Table%7302.al       # Warehouse Journal Line
+├── Table%7311.al       # Warehouse Journal Batch
+└── version             # BC version info
+```
+
+## File Size Distribution Example
+
+```
+245955 bytes  CodeUnit%6500.al    # Largest AL file - complex codeunit
+187052 bytes  Table%27.al         # Item table
+ 71800 bytes  225.mdc             # Largest trace - rich variable data
+  9928 bytes  19.mdc              # Medium trace - some variables
+  1624 bytes  185.mdc             # Small trace - call stack only
+   392 bytes  0.mdc               # Minimal - session start
+```
+
+## App Metadata from .mdc File
+
+Raw hex showing readable app info:
+```
+3433 3764 6266 3065 3834 6666   437dbf0e84ff
+3431 3761 3936 3564 6564 3262   417a965ded2b
+6239 3635 3039 3732             b9650972
+
+3236 2e35 2e33 3837 3532 2e34   26.5.38752.4
+3233 3035                       2305
+
+4d69 6372 6f73 6f66 74         Microsoft
+
+4261 7365 2041 7070 6c69 6361  Base Applica
+7469 6f6e                       tion
+```
+
+Decoded:
+- App ID: `437dbf0e84ff417a965ded2bb9650972`
+- Version: `26.5.38752.42305`
+- Publisher: `Microsoft`
+- App Name: `Base Application`
+
+## Object ID Decoding
+
+| URL-Encoded Name | Decoded | Object |
+|------------------|---------|--------|
+| `CodeUnit%6500.al` | Codeunit 6500 | Item Tracking Management |
+| `Table%27.al` | Table 27 | Item |
+| `Page%7324.al` | Page 7324 | Whse. Item Journal |
+| `Table%6550.al` | Table 6550 | Whse. Item Tracking Line |
+
+## Counting Execution Steps
+
+```bash
+# Count total .mdc files
+ls *.mdc | wc -l
+# Result: 579 (579 execution steps captured)
+
+# Find the last step number
+ls *.mdc | sed 's/.mdc//' | sort -n | tail -1
+# Result: 578 (files numbered 0-578)
+```
+
+## Sorting by Size to Find Key Files
+
+```bash
+# List files by size (largest first)
+ls -laS *.mdc | head -10
+
+# Result shows 225.mdc at 71KB - likely has rich debug data
+```

--- a/domains/dean-debug/snapshot-analysis-workflow.md
+++ b/domains/dean-debug/snapshot-analysis-workflow.md
@@ -1,0 +1,141 @@
+---
+title: "Snapshot Debugging Analysis Workflow"
+domain: "dean-debug"
+difficulty: "intermediate"
+bc_versions: "14+"
+tags: ["debugging", "snapshot", "workflow", "troubleshooting", "analysis"]
+samples: "samples/snapshot-analysis-workflow.md"
+type: "best-practice"
+category: "debugging"
+pattern_type: "good"
+severity: "medium"
+impact_level: "high"
+
+relevance_signals:
+  constructs: []
+  keywords: ["snapshot", "debug", "analyze", "troubleshoot", "trace", "investigation"]
+  anti_pattern_indicators: []
+  positive_pattern_indicators: ["snapshot analysis", "debug workflow", "trace review"]
+
+applicable_object_types: ["codeunit", "page", "table", "report", "query"]
+
+relevance_threshold: 0.5
+---
+
+# Snapshot Debugging Analysis Workflow
+
+## Overview
+
+This workflow guides you through analyzing an extracted BC snapshot to understand execution flow, identify issues, and examine variable values. Follow these steps systematically to extract maximum insight from captured debug sessions.
+
+**Core Principle**: Start broad (understand the scope), then narrow down (find key moments), then dive deep (examine specific values).
+
+## Phase 1: Initial Assessment
+
+### Understand the Scope
+1. **Count .mdc files** to know how many execution steps were captured
+2. **List .al files** to see which objects were involved
+3. **Check the version file** for BC platform version
+
+### Identify Key Objects
+Look at the AL file names to understand the functional area:
+- `CodeUnit%6500.al` = Item Tracking Management
+- `Table%27.al` = Item table
+- `Page%7324.al` = Whse. Item Journal
+
+Decode the URL-encoded names (% followed by number = that object ID).
+
+## Phase 2: Find Key Execution Points
+
+### Locate Large .mdc Files
+Sort .mdc files by size - larger files contain more variable data:
+- Files over 10KB often contain breakpoint data or key state captures
+- The largest file typically has the richest debugging information
+
+### Identify Execution Boundaries
+- **File 0.mdc**: Session start point
+- **Highest numbered file**: Session end or last captured step
+- **Size spikes**: Often indicate where interesting activity occurred
+
+## Phase 3: Extract Call Stack
+
+### Read Stack from .mdc Files
+Open an .mdc file in a hex viewer or read the raw bytes. Look for readable text showing:
+1. Object names (e.g., "Whse. Item Journal")
+2. Procedure names (e.g., "OnAfterGetRecord", "Code")
+3. These form the call stack from entry point to current execution
+
+### Trace Execution Flow
+Follow the numbered sequence of .mdc files to understand:
+- Which procedure called which
+- The order of trigger execution
+- When control passed between objects
+
+## Phase 4: Examine Variable Values
+
+### Find Variable Data in Large .mdc Files
+Search for patterns like:
+- `Boolean` followed by `True`/`False`
+- `Decimal` followed by numeric values
+- `Text[` or `Code[` followed by string values
+- `GUID` followed by bracketed GUIDs
+- `DateTime` followed by formatted timestamps
+
+### Match Fields to Records
+When you see field names like:
+- `SystemModifiedAt`, `SystemCreatedBy` = System fields
+- Business field names = Record data at that execution point
+
+Look for `Count = N` to know how many fields follow for a record.
+
+## Phase 5: Correlate with Source Code
+
+### Use Line Numbers
+Extract line numbers from .mdc files (16-bit little-endian pairs):
+- First number = line number
+- Second number = column position
+
+### Cross-Reference .al Files
+Open the corresponding .al file from the snapshot and navigate to the line number to see exactly what code was executing.
+
+## Phase 6: Build the Story
+
+### Document Findings
+1. **Entry Point**: Which trigger/action started execution
+2. **Call Chain**: The sequence of procedure calls
+3. **Key Values**: What record data looked like at critical moments
+4. **Error Context**: If investigating an error, what state existed just before
+
+### Identify Root Cause
+Look for:
+- Unexpected variable values
+- Missing or null data where values were expected
+- Call stack showing unexpected code paths
+
+## Common Analysis Scenarios
+
+### Performance Investigation
+- Look at the total .mdc count (more files = more steps = potential inefficiency)
+- Check for repeated patterns in call stacks (loops)
+- Examine which objects are called most frequently
+
+### Error Investigation
+- Start from the last .mdc files (closest to the error)
+- Work backward through the call stack
+- Look for unexpected values or states
+
+### Logic Investigation
+- Follow the execution sequence step by step
+- Compare expected vs actual call paths
+- Examine decision point variables (booleans, options)
+
+## Summary
+
+- Start with scope assessment (file counts, objects involved)
+- Find key moments through file sizes and sequence
+- Extract call stacks and variable values from .mdc content
+- Correlate with source code using line numbers
+- Build a narrative of what happened and why
+
+*Code examples: see samples/snapshot-analysis-workflow.md*
+*Related patterns: snapshot-debugging-structure.md, mdc-file-format.md*

--- a/domains/dean-debug/snapshot-debugging-structure.md
+++ b/domains/dean-debug/snapshot-debugging-structure.md
@@ -1,0 +1,92 @@
+---
+title: "Snapshot Debugging File Structure"
+domain: "dean-debug"
+difficulty: "intermediate"
+bc_versions: "14+"
+tags: ["debugging", "snapshot", "troubleshooting", "production-debugging"]
+samples: "samples/snapshot-debugging-structure.md"
+type: "architecture-pattern"
+category: "debugging"
+pattern_type: "good"
+severity: "medium"
+impact_level: "high"
+
+relevance_signals:
+  constructs: []
+  keywords: ["snapshot", ".snap", "debug", "production", "trace", "call stack", "variable values"]
+  anti_pattern_indicators: []
+  positive_pattern_indicators: ["snapshot analysis", "debug trace", "offline debugging"]
+
+applicable_object_types: ["codeunit", "page", "table", "report", "query"]
+
+relevance_threshold: 0.5
+---
+
+# Snapshot Debugging File Structure
+
+## Overview
+
+Business Central snapshot files (.snap) are ZIP archives containing complete debugging session captures. They enable offline analysis of execution flow, call stacks, and variable values from production or sandbox environments without requiring a live debugger connection.
+
+**Core Principle**: Snapshots are structured archives with human-readable components that can be analyzed to understand exactly what happened during a captured session.
+
+## How It Works
+
+A .snap file is a ZIP archive containing:
+- **Numbered .mdc files** (0.mdc, 1.mdc, ..., N.mdc): Debug trace data for each execution step
+- **.al source files**: AL code for objects involved in the captured session
+- **version file**: BC platform version information
+
+The .mdc files form a sequential trace of execution:
+- File 0.mdc is the first captured step
+- Each subsequent file represents the next step in execution
+- Higher-numbered files occurred later in the session
+- The total count indicates how many steps were captured
+
+## When to Apply
+
+- Analyzing issues reported by users in production environments
+- Debugging intermittent problems that are hard to reproduce
+- Investigating performance issues in specific user workflows
+- Understanding complex call chains across multiple objects
+- Reviewing what values records contained at specific moments
+
+## Extracting Snapshot Contents
+
+### Step 1: Identify the Snapshot
+Snapshot files have the `.snap` extension and are downloaded from VS Code after a snapshot debugging session completes.
+
+### Step 2: Extract as ZIP
+Rename or extract the .snap file as a standard ZIP archive. The contents will include:
+- Numbered .mdc files (debug trace steps)
+- AL source files (URL-encoded names like `CodeUnit%6500.al`)
+- A version file
+
+### Step 3: Identify Session Scope
+Count the .mdc files to understand session length. A snapshot with 579 .mdc files captured 579 distinct execution steps.
+
+## File Name Decoding
+
+AL source files use URL encoding for special characters:
+- `%` followed by hex codes represent special characters
+- `CodeUnit%6500.al` = Codeunit 6500
+- `Table%27.al` = Table 27 (Item)
+- `Page%7324.al` = Page 7324
+
+## App Identification
+
+Each .mdc file contains app metadata:
+- **App ID**: GUID identifying the extension (e.g., `437dbf0e84ff417a965ded2bb9650972`)
+- **Version**: Full version string (e.g., `26.5.38752.42305`)
+- **Publisher**: Extension publisher (e.g., `Microsoft`)
+- **App Name**: Human-readable name (e.g., `Base Application`)
+
+## Summary
+
+- Snapshot files are ZIP archives containing structured debug data
+- .mdc files provide sequential execution trace with full context
+- AL source files are included for objects touched during the session
+- App metadata helps identify which extension code was executing
+
+*Code examples: see samples/snapshot-debugging-structure.md*
+*Related patterns: mdc-file-format.md, snapshot-analysis-workflow.md*

--- a/specialists/dean-debug.md
+++ b/specialists/dean-debug.md
@@ -21,6 +21,7 @@ when_to_use:
   - "Performance regression"
   - "System optimization"
   - "Production issues"
+  - "Snapshot debugging - analyzing .snap files and .mdc traces"
 collaboration:
   natural_handoffs:
     - "roger-reviewer"
@@ -123,6 +124,13 @@ Either way, let's solve this puzzle!
 - Performance regression detection and alerting
 - Proactive optimization and maintenance strategies
 - Performance culture and awareness building
+
+### **Snapshot Debugging Analysis** 📸
+- Analyzing extracted BC snapshot files (.snap archives)
+- Reading .mdc debug trace files to understand execution flow
+- Extracting call stacks, variable values, and record data from snapshots
+- Correlating .mdc line numbers with AL source code
+- Guiding users through offline debugging of production issues
 
 ## Dean's Diagnostic Process
 
@@ -275,6 +283,24 @@ Performance improvement deployment:
 
 **What specific performance goals are you trying to achieve?**"
 
+### **For Snapshot Debugging**
+"🔍 Dean here! I can help you analyze that BC snapshot file.
+
+**Snapshot Analysis Capabilities:**
+Snapshot files (.snap) are ZIP archives containing complete debug session captures. Once extracted, I can help you:
+
+1. **Understand the Scope** - Count execution steps, identify which objects were involved
+2. **Read Call Stacks** - Extract the execution path from .mdc trace files
+3. **Examine Variable Values** - Find record field values, booleans, quantities at each step
+4. **Correlate with Source Code** - Match line numbers to the included AL source files
+
+**To get started:**
+- Extract the .snap file as a ZIP archive
+- Share the path to the extracted folder
+- I'll guide you through analyzing the execution trace
+
+**What issue are you trying to debug with this snapshot?**"
+
 ## Collaboration & Handoffs
 
 ### **Natural Next Steps:**
@@ -328,6 +354,13 @@ Diagnostic Investigation Workflow (4 phases):
 3. Root Cause Analysis (systematic elimination, pattern identification)
 4. Solution Validation (measure improvement, verify no regressions)
 
+Snapshot Debugging Workflow:
+1. Scope Assessment (count .mdc files, identify involved objects)
+2. Key Point Discovery (find large .mdc files with rich data)
+3. Call Stack Extraction (read execution path from trace)
+4. Variable Analysis (examine record values at key moments)
+5. Source Correlation (match line numbers to AL code)
+
 **MY VOICE:**
 - Methodical detective: "Let's gather data before jumping to solutions..."
 - Evidence-focused: Every claim backed by measurements
@@ -363,3 +396,6 @@ Diagnostic Investigation Workflow (4 phases):
 - "We're treating symptoms - what's the root cause?"
 - "Can you reproduce this consistently?"
 - "Performance awareness prevents production surprises"
+- "Let's extract the call stack from the snapshot"
+- "The .mdc files show exactly what was executing"
+- "I can read the variable values at that execution point"


### PR DESCRIPTION
## Summary
- Add knowledge files teaching Dean Debug how to analyze BC snapshot (.snap) files
- Dean can now read .mdc debug trace files to extract call stacks, variable values, and correlate with AL source
- Updated specialist instructions with snapshot debugging workflow and response patterns

## New Knowledge Files
| File | Purpose |
|------|---------|
| `snapshot-debugging-structure.md` | ZIP archive anatomy (.mdc traces, .al sources, version) |
| `mdc-file-format.md` | Binary trace format - call stacks, line numbers, variable values |
| `snapshot-analysis-workflow.md` | Step-by-step debugging workflow |

## Key Discoveries
- Snapshots are ZIP files containing structured debug data
- .mdc files contain readable text with call stacks and variable values
- Line numbers map directly to included .al source files (little-endian 16-bit)
- Larger .mdc files contain richer data (record fields, variable states)

## Test plan
- [ ] Validate frontmatter passes (`./scripts/frontmatter_validator.ps1 -Path "domains/dean-debug" -ExcludeSamples`)
- [ ] Review knowledge file content for accuracy
- [ ] Test Dean Debug with an extracted snapshot folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)